### PR TITLE
Use macros and add full source URL

### DIFF
--- a/htslib.spec
+++ b/htslib.spec
@@ -6,9 +6,9 @@ Summary:        C library for high-throughput sequencing data formats
 # The entire source code is MIT except cram/ which is Modified-BSD
 License:        MIT and BSD
 URL:            http://www.htslib.org
-Source0:        %{name}-%{version}.tar.gz
+Source0:        https://github.com/samtools/%{name}/releases/download/%{version}/%{name}-%{version}.tar.bz2
 
-BuildRequires:	glibc-common, zlib-devel, ncurses
+BuildRequires:  glibc-common, zlib-devel, ncurses
 
 %description
 HTSlib is an implementation of a unified C library for accessing common file
@@ -40,10 +40,10 @@ developing applications that use %{name}.
 make %{?_smp_mflags}
 
 %install
-rm -rf $RPM_BUILD_ROOT
+rm -rf %{buildroot}
 %make_install prefix=/usr libdir=/usr/lib64
 make install-so %{?_smp_mflags} prefix=/usr libdir=/usr/lib64 DESTDIR=%{buildroot}
-find $RPM_BUILD_ROOT -name '*.la' -exec rm -f {} ';'
+find %{buildroot} -name '*.la' -exec rm -f {} ';'
 
 %post -p /sbin/ldconfig
 


### PR DESCRIPTION
This applies more up to date RPM idioms and uses the full source URL.

I've removed the tabs that `rpmlint` was complaining about.

There appears to be a problem with `rpmlint` source URL checks at the moment, which I've reported upstream.

You should also check whether those manual prefix steps are required. Normally you would expect the Fedora macros to fill those values.
